### PR TITLE
Cleanup

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -56,7 +56,7 @@ install:
 
     # Cywing's git breaks conda-build. (See https://github.com/conda-forge/conda-smithy-feedstock/pull/2.)
     - cmd: rmdir C:\cygwin /s /q
-    - appveyor DownloadFile "https://raw.githubusercontent.com/conda-forge/conda-smithy/master/bootstrap-obvious-ci-and-miniconda.py"
+    - appveyor DownloadFile "https://raw.githubusercontent.com/conda-forge/conda-smithy/e976c7e84bb3c4846e7562afd1a42c4b535b51f5/bootstrap-obvious-ci-and-miniconda.py"
     - cmd: python bootstrap-obvious-ci-and-miniconda.py %CONDA_INSTALL_LOCN% %TARGET_ARCH% %CONDA_PY:~0,1% --without-obvci
 
     # Add a hack to switch to `conda` version `4.1.12` before activating.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,6 +14,8 @@ source:
 build:
   number: 1
   script: python setup.py install --single-version-externally-managed --record=record.txt
+  entry_points:
+    - obvci_conda_build_dir = obvci.cli.conda_build_dir:main
 
 requirements:
   build:
@@ -22,7 +24,6 @@ requirements:
 
   run:
     - python
-    - setuptools
     - anaconda-client
     - conda
     - conda-build

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,6 +40,7 @@ test:
 about:
   home: https://github.com/pelson/Obvious-CI
   license: BSD 3-Clause
+  license_family: BSD
   summary: Tools to simplify Continuous Integration, particularly for conda building.
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     - miniconda_url.patch
 
 build:
-  number: 1
+  number: 2
   script: python setup.py install --single-version-externally-managed --record=record.txt
   entry_points:
     - obvci_conda_build_dir = obvci.cli.conda_build_dir:main

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,8 +1,8 @@
-{% set version="0.6.1" %}
+{% set version = "0.6.1" %}
 
 package:
   name: obvious-ci
-  version: {{version}}
+  version: {{ version }}
 
 source:
   url: https://github.com/pelson/Obvious-CI/archive/v{{ version }}.tar.gz
@@ -33,9 +33,10 @@ test:
     - obvci
     - obvci.conda_tools
     - obvci.cli
+
   commands:
     - unset CONDA_NPY && obvci_conda_build_dir --help  # [not win]
-    - obvci_conda_build_dir --help  # [win]
+    - obvci_conda_build_dir --help                     # [win]
 
 about:
   home: https://github.com/pelson/Obvious-CI

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,6 +41,7 @@ about:
   home: https://github.com/pelson/Obvious-CI
   license: BSD 3-Clause
   license_family: BSD
+  license_file: LICENSE
   summary: Tools to simplify Continuous Integration, particularly for conda building.
 
 extra:


### PR DESCRIPTION
* Re-renders with `conda-smithy` version `1.4.6`.
* Uses `conda-build` entry points.
* Packages the license.
* Updates some other metadata.
* Minor whitespace fixes.
* Bumps the build number.